### PR TITLE
Force use of dev-develop as v0.9 doesn't work

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "bshaffer/oauth2-server-bundle",
+    "name": "jdelaune/oauth2-server-bundle",
     "type": "symfony-bundle",
     "description": "Symfony OAuth2ServerBundle",
     "keywords": ["oauth", "oauth2", "security"],

--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,6 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "bshaffer/oauth2-server-php": "v0.9",
-        "bshaffer/oauth2-server-httpfoundation-bridge": "v0.9"
-    },
-    "require-dev": {
         "bshaffer/oauth2-server-php": "dev-develop",
         "bshaffer/oauth2-server-httpfoundation-bridge": "dev-develop"
     },

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "jdelaune/oauth2-server-bundle",
+    "name": "bshaffer/oauth2-server-bundle",
     "type": "symfony-bundle",
     "description": "Symfony OAuth2ServerBundle",
     "keywords": ["oauth", "oauth2", "security"],


### PR DESCRIPTION
Hey,

I want to work on getting a more fully implemented Symfony 2 version of your PHP library written. First thing I noticed is that the dev-develop branch has to be used in Symfony because the class was previously named OAuth2_Server instead of just Server which the dependency injection doesn't like.

Don't know how familiar you are with Symfony 2, I wouldn't call myself an expert, but maybe if I do some stuff you can check it over and see if it's any good.
