### PR TITLE
Move finding of scopes into scope manager

### DIFF
--- a/Manager/ClientManager.php
+++ b/Manager/ClientManager.php
@@ -9,9 +9,15 @@ class ClientManager
 {
     private $em;
 
-    public function __construct(EntityManager $entityManager)
+    /**
+     * @var ScopeManagerInterface
+     */
+    private $sm;
+
+    public function __construct(EntityManager $entityManager, ScopeManagerInterface $scopeManager)
     {
         $this->em = $entityManager;
+        $this->sm = $scopeManager;
     }
 
     /**
@@ -38,7 +44,7 @@ class ClientManager
         // Verify scopes
         foreach ($scopes as $scope) {
             // Get Scope
-            $scopeObject = $this->em->getRepository('OAuth2ServerBundle:Scope')->find($scope);
+            $scopeObject = $this->sm->findScopeByScope($scope);
             if (!$scopeObject) {
                 throw new ScopeNotFoundException();
             }

--- a/Manager/ScopeManager.php
+++ b/Manager/ScopeManager.php
@@ -4,7 +4,7 @@ namespace OAuth2\ServerBundle\Manager;
 
 use Doctrine\ORM\EntityManager;
 
-class ScopeManager
+class ScopeManager implements ScopeManagerInterface
 {
     private $em;
 
@@ -33,5 +33,35 @@ class ScopeManager
         $this->em->flush();
 
         return $scopeObject;
+    }
+
+    /**
+     * Find a single scope by the scope
+     *
+     * @param $scope
+     * @return Scope
+     */
+    public function findScopeByScope($scope)
+    {
+        $scopeObject = $this->em->getRepository('OAuth2ServerBundle:Scope')->find($scope);
+
+        return $scopeObject;
+    }
+
+    /**
+     * Find all the scopes by an array of scopes
+     *
+     * @param array $scopes
+     * @return mixed|void
+     */
+    public function findScopesByScopes(array $scopes)
+    {
+        $scopeObjects = $this->em->getRepository('OAuth2ServerBundle:Scope')
+            ->createQueryBuilder('a')
+            ->where('a.scope in (?1)')
+            ->setParameter(1, implode(',', $scopes))
+            ->getQuery()->getResult();
+
+        return $scopeObjects;
     }
 }

--- a/Manager/ScopeManagerInterface.php
+++ b/Manager/ScopeManagerInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace OAuth2\ServerBundle\Manager;
+
+use Doctrine\ORM\EntityManager;
+
+interface ScopeManagerInterface
+{
+    public function __construct(EntityManager $entityManager);
+
+    /**
+     * Creates a new scope
+     *
+     * @param string $scope
+     *
+     * @param string $description
+     *
+     * @return Scope
+     */
+    public function createScope($scope, $description = null);
+
+    /**
+     * Find a single scope by the scope
+     *
+     * @param $scope
+     * @return Scope
+     */
+    public function findScopeByScope($scope);
+
+    /**
+     * Find all the scopes by an array of scopes
+     *
+     * @param array $scopes
+     * @return mixed
+     */
+    public function findScopesByScopes(array $scopes);
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -38,6 +38,9 @@
             <argument type="service" id="doctrine.orm.entity_manager"/>
             <argument type="service" id="security.encoder_factory"/>
         </service>
+        <service id="oauth2.scope_manager" class="%oauth2.scope_manager.class%">
+            <argument type="service" id="doctrine.orm.entity_manager"/>
+        </service>
         <service id="oauth2.storage.client_credentials" class="%oauth2.storage.client_credentials.class%">
             <argument type="service" id="doctrine.orm.entity_manager"/>
         </service>
@@ -57,6 +60,7 @@
         </service>
         <service id="oauth2.storage.scope" class="%oauth2.storage.scope.class%">
             <argument type="service" id="doctrine.orm.entity_manager"/>
+            <argument type="service" id="oauth2.scope_manager"/>
         </service>
         <service id="oauth2.grant_type.client_credentials" class="%oauth2.grant_type.client_credentials.class%">
             <argument type="service" id="oauth2.storage.client_credentials"/>
@@ -75,9 +79,7 @@
         </service>
         <service id="oauth2.client_manager" class="%oauth2.client_manager.class%">
             <argument type="service" id="doctrine.orm.entity_manager"/>
-        </service>
-        <service id="oauth2.scope_manager" class="%oauth2.scope_manager.class%">
-            <argument type="service" id="doctrine.orm.entity_manager"/>
+            <argument type="service" id="oauth2.scope_manager"/>
         </service>
     </services>
 </container>

--- a/Storage/Scope.php
+++ b/Storage/Scope.php
@@ -3,15 +3,22 @@
 namespace OAuth2\ServerBundle\Storage;
 
 use OAuth2\Storage\ScopeInterface;
+use OAuth2\ServerBundle\Manager\ScopeManagerInterface;
 use Doctrine\ORM\EntityManager;
 
 class Scope implements ScopeInterface
 {
     private $em;
 
-    public function __construct(EntityManager $entityManager)
+    /**
+     * @var ScopeManagerInterface
+     */
+    private $sm;
+
+    public function __construct(EntityManager $entityManager, ScopeManagerInterface $scopeManager)
     {
         $this->em = $entityManager;
+        $this->sm = $scopeManager;
     }
 
     /**
@@ -47,11 +54,7 @@ class Scope implements ScopeInterface
             return true;
         }
 
-        $valid_scopes = $this->em->getRepository('OAuth2ServerBundle:Scope')
-            ->createQueryBuilder('a')
-            ->where('a.scope in (?1)')
-            ->setParameter(1, implode(',', $scopes))
-            ->getQuery()->getResult();
+        $valid_scopes = $this->sm->findScopesByScopes($scopes);
 
         return count($valid_scopes) == count($scopes);
     }
@@ -88,7 +91,7 @@ class Scope implements ScopeInterface
     public function getDescriptionForScope($scope)
     {
         // Get Scope
-        $scopeObject = $this->em->getRepository('OAuth2ServerBundle:Scope')->find($scope);
+        $scopeObject = $this->sm->findScopeByScope($scope);
 
         if (!$scopeObject) {
             return $scope;


### PR DESCRIPTION
Maybe I'm barking up the wrong tree here, but let me know before I get too far down this path.

Basically we wanted to replace the Scope entity (so we can add extra field for referential integrity). We've already done it with the User and that was easy as you provide your own UserProvider and all is well. With scopes it wasn't so simple as the Client Manager and Scope storage both fetch scopes using the OAuth2ServerBundle:Scope repository. Meaning we'd have to extend/replace the scope storage and client manager if we wanted to use our own Scope entity.

All I've done here is have the Scope manager handle the two cases where you're fetching scopes. The manager service is passed into the Client Manager and the Scope storage.

I created a ScopeManagerInterface so anyone replacing the scope manager (like we wish to) can implement it to make sure they have the required methods.

This could also be done for Clients too.
