### PR TITLE
Fixing scope problem. Should return string, was returing an array.

### DIFF
--- a/Storage/ClientCredentials.php
+++ b/Storage/ClientCredentials.php
@@ -163,6 +163,7 @@ class ClientCredentials implements ClientCredentialsInterface
             return false;
         }
 
-        return $client->getScopes();
+        $scopes = implode(" ", $client->getScopes());
+        return $scopes;
     }
 }


### PR DESCRIPTION
The getClientScope function should return a string, but the $client->getScopes() function was returning an array. This fixes it so it's returning properly.
