### PR TITLE
Bugfix: getClientScope should return a string

### DIFF
--- a/Storage/ClientCredentials.php
+++ b/Storage/ClientCredentials.php
@@ -163,6 +163,6 @@ class ClientCredentials implements ClientCredentialsInterface
             return false;
         }
 
-        return $client->getScopes();
+        return implode(',', $client->getScopes());
     }
 }


### PR DESCRIPTION
Doctrine returns it as an array but ClientInterface demands a string.
