### PR TITLE
Suppressing Symfony 2.7 deprecation alerts

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -30,7 +30,8 @@
                 <argument type="service" id="oauth2.storage.scope" />
             </argument>
         </service>
-        <service id="oauth2.request" class="%oauth2.request.class%" factory-class="OAuth2\HttpFoundationBridge\Request" factory-method="createFromRequest" scope="request">
+        <service id="oauth2.request" class="%oauth2.request.class%" scope="request">
+            <factory class="OAuth2\HttpFoundationBridge\Request" method="createFromRequest" />
             <argument type="service" id="request"/>
         </service>
         <service id="oauth2.response" class="%oauth2.response.class%"/>


### PR DESCRIPTION
I was trying to install this bundle with Symfony 2.7 but I was getting a lot of deprecation notices when running some CLI commands. I found out that changing just the services.xml to a different format fixed it.
