### PR TITLE
make config compatible with symfony 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ php:
   - 5.4
   - 5.5
   - 5.6
-  - 7.0
 env:
   - CONTAINER_CONFIG=Tests/Resources/config/services.xml
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
-  - 5.5
+  - 5.5.9
+  - 5.6
+  - 7.0
 env:
   - CONTAINER_CONFIG=Tests/Resources/config/services.xml
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ php:
   - 5.3
   - 5.4
   - 5.5
+  - 5.6
+  - 7.0
 env:
   - CONTAINER_CONFIG=Tests/Resources/config/services.xml
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
+  - 5.3
   - 5.4
   - 5.5
-  - 5.6
 env:
   - CONTAINER_CONFIG=Tests/Resources/config/services.xml
 before_script:

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -34,8 +34,9 @@
             </argument>
             <argument>%oauth2.server.config%</argument>
         </service>
-        <service id="oauth2.request" class="%oauth2.request.class%" factory-class="OAuth2\HttpFoundationBridge\Request" factory-method="createFromRequest" scope="request">
-            <argument type="service" id="request"/>
+        <service id="oauth2.request" class="%oauth2.request.class%">
+            <factory class="OAuth2\HttpFoundationBridge\Request" method="createFromRequest" />
+            <argument type="service" id="request_stack"/>
         </service>
         <service id="oauth2.response" class="%oauth2.response.class%"/>
         <service id="oauth2.user_provider" class="%oauth2.user_provider.class%">

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -24,13 +24,13 @@
     <services>
         <service id="oauth2.server" class="%oauth2.server.class%">
             <argument key="oauth2.server.storage" type="collection">
-                <argument type="service" key="client_credentials" id="oauth2.storage.client_credentials" />
-                <argument type="service" key="access_token" id="oauth2.storage.access_token" />
-                <argument type="service" key="authorization_code" id="oauth2.storage.authorization_code" />
-                <argument type="service" key="user_credentials" id="oauth2.storage.user_credentials" />
-                <argument type="service" key="refresh_token" id="oauth2.storage.refresh_token" />
-                <argument type="service" key="scope" id="oauth2.storage.scope" />
-                <argument type="service" key="public_key" id="oauth2.storage.public_key" />
+                <argument type="service" id="oauth2.storage.client_credentials" />
+                <argument type="service" id="oauth2.storage.access_token" />
+                <argument type="service" id="oauth2.storage.authorization_code" />
+                <argument type="service" id="oauth2.storage.user_credentials" />
+                <argument type="service" id="oauth2.storage.refresh_token" />
+                <argument type="service" id="oauth2.storage.scope" />
+                <argument type="service" id="oauth2.storage.public_key" />
             </argument>
             <argument>%oauth2.server.config%</argument>
         </service>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -35,7 +35,7 @@
             <argument>%oauth2.server.config%</argument>
         </service>
         <service id="oauth2.request" class="%oauth2.request.class%">
-            <factory class="OAuth2\HttpFoundationBridge\Request" method="createFromRequest" />
+            <factory class="OAuth2\HttpFoundationBridge\Request" method="createFromRequestStack" />
             <argument type="service" id="request_stack"/>
         </service>
         <service id="oauth2.response" class="%oauth2.response.class%"/>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -24,13 +24,13 @@
     <services>
         <service id="oauth2.server" class="%oauth2.server.class%">
             <argument key="oauth2.server.storage" type="collection">
-                <argument type="service" id="oauth2.storage.client_credentials" />
-                <argument type="service" id="oauth2.storage.access_token" />
-                <argument type="service" id="oauth2.storage.authorization_code" />
-                <argument type="service" id="oauth2.storage.user_credentials" />
-                <argument type="service" id="oauth2.storage.refresh_token" />
-                <argument type="service" id="oauth2.storage.scope" />
-                <argument type="service" id="oauth2.storage.public_key" />
+                <argument type="service" key="client_credentials" id="oauth2.storage.client_credentials" />
+                <argument type="service" key="access_token" id="oauth2.storage.access_token" />
+                <argument type="service" key="authorization_code" id="oauth2.storage.authorization_code" />
+                <argument type="service" key="user_credentials" id="oauth2.storage.user_credentials" />
+                <argument type="service" key="refresh_token" id="oauth2.storage.refresh_token" />
+                <argument type="service" key="scope" id="oauth2.storage.scope" />
+                <argument type="service" key="public_key" id="oauth2.storage.public_key" />
             </argument>
             <argument>%oauth2.server.config%</argument>
         </service>

--- a/Tests/Resources/config/services.xml
+++ b/Tests/Resources/config/services.xml
@@ -25,7 +25,7 @@
             </argument>
             <argument type="service" id="doctrine.entity_manager.config" />
         </service>
-        <service id="doctrine.entity_manager.config" class="Doctrine\ORM\Tools\Setup"c>
+        <service id="doctrine.entity_manager.config" class="Doctrine\ORM\Tools\Setup">
             <factory class="Doctrine\ORM\Tools\Setup" method="createConfiguration" />
             <argument>true</argument>
             <call method="setMetadataDriverImpl">

--- a/Tests/Resources/config/services.xml
+++ b/Tests/Resources/config/services.xml
@@ -14,7 +14,8 @@
         </parameter>
     </parameters>
     <services>
-        <service id="doctrine.orm.entity_manager" class="Doctrine\ORM\EntityManager" factory-class="Doctrine\ORM\EntityManager" factory-method="create">
+        <service id="doctrine.orm.entity_manager" class="Doctrine\ORM\EntityManager">
+            <factory class="Doctrine\ORM\EntityManager" method="create" />
             <argument type="collection">
                 <argument key="driver">%doctrine.db.driver%</argument>
                 <argument key="user">%doctrine.db.username%</argument>
@@ -24,7 +25,8 @@
             </argument>
             <argument type="service" id="doctrine.entity_manager.config" />
         </service>
-        <service id="doctrine.entity_manager.config" class="Doctrine\ORM\Tools\Setup" factory-class="Doctrine\ORM\Tools\Setup" factory-method="createConfiguration">
+        <service id="doctrine.entity_manager.config" class="Doctrine\ORM\Tools\Setup"c>
+            <factory class="Doctrine\ORM\Tools\Setup" method="createConfiguration" />
             <argument>true</argument>
             <call method="setMetadataDriverImpl">
                 <argument type="service" id="doctrine.entity_manager.driver.yaml" />

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=5.5.9",
         "bshaffer/oauth2-server-php": ">=1.0",
-        "bshaffer/oauth2-server-httpfoundation-bridge": ">=1.0"
+        "elhachmi/oauth2-server-httpfoundation-bridge": ">=1.0"
     },
     "require-dev": {
         "symfony/symfony":                  "3.0.*",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": ">=5.5.9",
         "bshaffer/oauth2-server-php": ">=1.0",
-        "elhachmi/oauth2-server-httpfoundation-bridge": "dev-develop"
+        "elhachmi/oauth2-server-httpfoundation-bridge": "dev-@dev"
     },
     "require-dev": {
         "symfony/symfony":                  "3.0.*",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "bshaffer/oauth2-server-httpfoundation-bridge": ">=1.0"
     },
     "require-dev": {
-        "symfony/symfony":                  "2.5.*",
+        "symfony/symfony":                  "3.0.*",
         "doctrine/orm":                     "2.4.*"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": ">=5.5.9",
         "bshaffer/oauth2-server-php": ">=1.0",
-        "elhachmi/oauth2-server-httpfoundation-bridge": "dev-develop"
+        "elhachmi/oauth2-server-httpfoundation-bridge": "dev-v1.2"
     },
     "require-dev": {
         "symfony/symfony":                  "3.0.*",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "elhachmi/oauth2-server-bundle",
+    "name": "bshaffer/oauth2-server-bundle",
     "type": "symfony-bundle",
     "description": "Symfony OAuth2ServerBundle",
     "keywords": ["oauth", "oauth2", "security"],
@@ -12,9 +12,14 @@
         }
     ],
     "minimum-stability":"dev",
+    "require": {
+        "php": ">=5.3.0",
+        "bshaffer/oauth2-server-php": ">=1.0",
+        "bshaffer/oauth2-server-httpfoundation-bridge": ">=1.0"
+    },
     "require-dev": {
-        "symfony/symfony":                  "3.0.*",
-        "doctrine/orm":                     "~2.4,>=2.4.5"
+        "symfony/symfony":                  "2.5.*",
+        "doctrine/orm":                     "2.4.*"
     },
     "autoload": {
         "psr-0": { "OAuth2\\ServerBundle": "" }

--- a/composer.json
+++ b/composer.json
@@ -12,17 +12,6 @@
         }
     ],
     "minimum-stability":"dev",
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/elhachmi/oauth2-server-httpfoundation-bridge.git"
-        }
-    ],
-    "require": {
-        "php": ">=5.5.9",
-        "bshaffer/oauth2-server-php": ">=1.0",
-        "elhachmi/oauth2-server-httpfoundation-bridge": "1.2"
-    },
     "require-dev": {
         "symfony/symfony":                  "3.0.*",
         "doctrine/orm":                     "~2.4,>=2.4.5"

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "repositories": [
         {
             "type": "vcs",
-            "url": "git@github.com:elhachmi/oauth2-server-httpfoundation-bridge.git"
+            "url": "https://github.com/elhachmi/oauth2-server-httpfoundation-bridge.git"
         }
     ],
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=5.3.0",
         "bshaffer/oauth2-server-php": ">=1.0",
-        "bshaffer/oauth2-server-httpfoundation-bridge": ">=1.0"
+        "bshaffer/oauth2-server-httpfoundation-bridge": "@dev"
     },
     "require-dev": {
         "symfony/symfony":                  "3.0.*",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "minimum-stability":"dev",
     "require": {
-        "php": ">=5.5.9",
+        "php": ">=5.3",
         "bshaffer/oauth2-server-php": ">=1.0",
         "bshaffer/oauth2-server-httpfoundation-bridge": "@dev"
     },

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=5.5.9",
         "bshaffer/oauth2-server-php": ">=1.0",
-        "elhachmi/oauth2-server-httpfoundation-bridge": "@dev"
+        "elhachmi/oauth2-server-httpfoundation-bridge": "*"
     },
     "require-dev": {
         "symfony/symfony":                  "3.0.*",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=5.5.9",
         "bshaffer/oauth2-server-php": ">=1.0",
-        "elhachmi/oauth2-server-httpfoundation-bridge": "develop"
+        "elhachmi/oauth2-server-httpfoundation-bridge": "@dev"
     },
     "require-dev": {
         "symfony/symfony":                  "3.0.*",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": ">=5.5.9",
         "bshaffer/oauth2-server-php": ">=1.0",
-        "elhachmi/oauth2-server-httpfoundation-bridge": "@dev"
+        "elhachmi/oauth2-server-httpfoundation-bridge": "dev-develop"
     },
     "require-dev": {
         "symfony/symfony":                  "3.0.*",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": ">=5.5.9",
         "bshaffer/oauth2-server-php": ">=1.0",
-        "elhachmi/oauth2-server-httpfoundation-bridge": "dev-v1.2"
+        "elhachmi/oauth2-server-httpfoundation-bridge": "v1.2"
     },
     "require-dev": {
         "symfony/symfony":                  "3.0.*",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=5.5.9",
         "bshaffer/oauth2-server-php": ">=1.0",
-        "elhachmi/oauth2-server-httpfoundation-bridge": "*"
+        "bshaffer/oauth2-server-httpfoundation-bridge": ">=1.0"
     },
     "require-dev": {
         "symfony/symfony":                  "3.0.*",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": ">=5.5.9",
         "bshaffer/oauth2-server-php": ">=1.0",
-        "elhachmi/oauth2-server-httpfoundation-bridge": "dev-@dev"
+        "elhachmi/oauth2-server-httpfoundation-bridge": "@dev"
     },
     "require-dev": {
         "symfony/symfony":                  "3.0.*",

--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,16 @@
         }
     ],
     "minimum-stability":"dev",
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "git@github.com:elhachmi/oauth2-server-httpfoundation-bridge.git"
+        }
+    ],
     "require": {
         "php": ">=5.5.9",
         "bshaffer/oauth2-server-php": ">=1.0",
-        "elhachmi/oauth2-server-httpfoundation-bridge": "@dev"
+        "elhachmi/oauth2-server-httpfoundation-bridge": "dev-develop"
     },
     "require-dev": {
         "symfony/symfony":                  "3.0.*",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=5.5.9",
         "bshaffer/oauth2-server-php": ">=1.0",
-        "bshaffer/oauth2-server-httpfoundation-bridge": ">=1.0"
+        "elhachmi/oauth2-server-httpfoundation-bridge": "develop"
     },
     "require-dev": {
         "symfony/symfony":                  "3.0.*",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": ">=5.5.9",
         "bshaffer/oauth2-server-php": ">=1.0",
-        "elhachmi/oauth2-server-httpfoundation-bridge": "v1.2"
+        "elhachmi/oauth2-server-httpfoundation-bridge": "1.2"
     },
     "require-dev": {
         "symfony/symfony":                  "3.0.*",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "bshaffer/oauth2-server-bundle",
+    "name": "elhachmi/oauth2-server-bundle",
     "type": "symfony-bundle",
     "description": "Symfony OAuth2ServerBundle",
     "keywords": ["oauth", "oauth2", "security"],

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=5.5.9",
         "bshaffer/oauth2-server-php": ">=1.0",
-        "elhachmi/oauth2-server-httpfoundation-bridge": ">=1.0"
+        "elhachmi/oauth2-server-httpfoundation-bridge": "@dev"
     },
     "require-dev": {
         "symfony/symfony":                  "3.0.*",

--- a/composer.json
+++ b/composer.json
@@ -13,13 +13,13 @@
     ],
     "minimum-stability":"dev",
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=5.5.9",
         "bshaffer/oauth2-server-php": ">=1.0",
         "bshaffer/oauth2-server-httpfoundation-bridge": ">=1.0"
     },
     "require-dev": {
         "symfony/symfony":                  "3.0.*",
-        "doctrine/orm":                     "2.4.*"
+        "doctrine/orm":                     "~2.4,>=2.4.5"
     },
     "autoload": {
         "psr-0": { "OAuth2\\ServerBundle": "" }

--- a/composer.json
+++ b/composer.json
@@ -13,13 +13,13 @@
     ],
     "minimum-stability":"dev",
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=5.5.9",
         "bshaffer/oauth2-server-php": ">=1.0",
         "bshaffer/oauth2-server-httpfoundation-bridge": "@dev"
     },
     "require-dev": {
-        "symfony/symfony":                  "3.0.*",
-        "doctrine/orm":                     "2.4.*"
+        "symfony/symfony": "3.0.*",
+        "doctrine/orm": "~2.4,>=2.4.5"
     },
     "autoload": {
         "psr-0": { "OAuth2\\ServerBundle": "" }


### PR DESCRIPTION
The container scope is deprecated in Symfony 2.8 and it has been removed in Symfony 3.0.
The methods Definition::setFactoryClass(), Definition::setFactoryMethod(), and Definition::setFactoryService() have been removed in symfony 3.0.
The request service was removed in symfony 3.0 in favor of the request_stack.
