### PR TITLE
Working scope query

### DIFF
--- a/Manager/ScopeManager.php
+++ b/Manager/ScopeManager.php
@@ -59,7 +59,7 @@ class ScopeManager implements ScopeManagerInterface
         $scopeObjects = $this->em->getRepository('OAuth2ServerBundle:Scope')
             ->createQueryBuilder('a')
             ->where('a.scope in (?1)')
-            ->setParameter(1, implode(',', $scopes))
+            ->setParameter(1, $scopes)
             ->getQuery()->getResult();
 
         return $scopeObjects;

--- a/Tests/Manager/ScopeManagerTest.php
+++ b/Tests/Manager/ScopeManagerTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace OAuth2\ServerBundle\Tests\Entity;
+
+use OAuth2\ServerBundle\Manager\ScopeManager;
+use OAuth2\ServerBundle\Tests\ContainerLoader;
+
+class ScopeManagerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFindScopesByScopes()
+    {
+        $container = ContainerLoader::buildTestContainer();
+        $em = $container->get('doctrine.orm.entity_manager');
+
+        $manager = new ScopeManager($em);
+
+        $scopes = ['test-scope-'.rand(), 'test-scope-'.rand(), 'test-scope-'.rand()];
+
+        foreach ($scopes as $scope) {
+            $manager->createScope($scope);
+        }
+
+        $dbScopes = $manager->findScopesByScopes($scopes);
+
+        $this->assertNotNull($dbScopes);
+        $this->assertEquals(count($dbScopes), count($scopes));
+    }
+}

--- a/Tests/Manager/ScopeManagerTest.php
+++ b/Tests/Manager/ScopeManagerTest.php
@@ -14,10 +14,10 @@ class ScopeManagerTest extends \PHPUnit_Framework_TestCase
 
         $manager = new ScopeManager($em);
 
-        $scopes = ['test-scope-'.rand(), 'test-scope-'.rand(), 'test-scope-'.rand()];
+        $scopes = array('test-scope-'.rand(), 'test-scope-'.rand(), 'test-scope-'.rand());
 
         foreach ($scopes as $scope) {
-            $manager->createScope($scope);
+            $manager->createScope($scope, $scope);
         }
 
         $dbScopes = $manager->findScopesByScopes($scopes);


### PR DESCRIPTION
Changed the scope query to allow multiple scopes. (Doctrine 2.5.6)

Before:
SELECT o0_.scope AS scope_0, o0_.description AS description_1 FROM oauth_scope o0_ WHERE o0_.scope IN ('scope1,scope2,scope3');

After
SELECT o0_.scope AS scope_0, o0_.description AS description_1 FROM oauth_scope o0_ WHERE o0_.scope IN ('scope1', 'scope2', 'scope3');

I also added a unit test but was unable to execute unit tests at all, some configuration problem i guess. Only tested with my symfony application.