### PR TITLE
Dispatching an event when an error occurred while using the token endpoint

### DIFF
--- a/Controller/TokenController.php
+++ b/Controller/TokenController.php
@@ -2,6 +2,7 @@
 
 namespace OAuth2\ServerBundle\Controller;
 
+use OAuth2\ServerBundle\Event\OauthTokenResponseErrorEvent;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 
@@ -9,7 +10,7 @@ class TokenController extends Controller
 {
     /**
      * This is called by the client app once the client has obtained
-     * an authorization code from the Authorize Controller (@see OAuth2\ServerBundle\Controller\AuthorizeController).
+     * an authorization code from the Authorize Controller (@see \OAuth2\ServerBundle\Controller\AuthorizeController).
      * returns a JSON-encoded Access Token or a JSON object with
      * "error" and "error_description" properties.
      *
@@ -25,6 +26,21 @@ class TokenController extends Controller
         $server->addGrantType($this->get('oauth2.grant_type.refresh_token'));
         $server->addGrantType($this->get('oauth2.grant_type.user_credentials'));
 
-        return $server->handleTokenRequest($this->get('oauth2.request'), $this->get('oauth2.response'));
+        /** @var \OAuth2\HttpFoundationBridge\Response $response */
+        $response = $server->handleTokenRequest($this->get('oauth2.request'), $this->get('oauth2.response'));
+
+        if ($response->getStatusCode() < 200 || $response->getStatusCode() >= 300) {
+            $requestParameters = $this->get('oauth2.request')->request->all();
+
+            if (isset($requestParameters['password'])) {
+                unset($requestParameters['password']);
+            }
+
+            $oauthTokenRequestErrorEvent = new OauthTokenResponseErrorEvent($response->getStatusCode(), $response->getParameter('error'),
+                $response->getParameter('error_description'), $requestParameters);
+            $this->get('event_dispatcher')->dispatch(OauthTokenResponseErrorEvent::NAME, $oauthTokenRequestErrorEvent);
+        }
+
+        return $response;
     }
 }

--- a/Event/OauthTokenResponseErrorEvent.php
+++ b/Event/OauthTokenResponseErrorEvent.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace OAuth2\ServerBundle\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+class OauthTokenResponseErrorEvent extends Event
+{
+    const NAME = 'oauth.token.response.error';
+
+    /*
+     * @var int
+     */
+    protected $statusCode;
+
+    /**
+     * @var string
+     */
+    protected $error;
+
+    /**
+     * @var string
+     */
+    protected $errorDescription;
+
+    /**
+     * @var array
+     */
+    protected $requestParameters;
+
+    public function __construct($statusCode, $error, $errorDescription, array $requestParameters)
+    {
+        $this->statusCode = $statusCode;
+        $this->error = $error;
+        $this->errorDescription = $errorDescription;
+        $this->requestParameters = $requestParameters;
+    }
+
+    /**
+     * @return int
+     */
+    public function getStatusCode()
+    {
+        return $this->statusCode;
+    }
+
+    /**
+     * @return string
+     */
+    public function getError()
+    {
+        return $this->error;
+    }
+
+    /**
+     * @return string
+     */
+    public function getErrorDescription()
+    {
+        return $this->errorDescription;
+    }
+
+    /**
+     * @return array
+     */
+    public function getRequestParameters()
+    {
+        return $this->requestParameters;
+    }
+
+    /**
+     * @param string $parameterName
+     * @return mixed|null
+     */
+    public function getRequestParameter($parameterName)
+    {
+        return isset($this->requestParameters[$parameterName]) ? $this->requestParameters[$parameterName] : null;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,7 @@
     },
     "require-dev": {
         "symfony/symfony": "^2.8|^3",
-        "doctrine/orm": "~2.4,>=2.4.5",
-        "phpunit/phpunit": "~6.2"
+        "doctrine/orm": "~2.4,>=2.4.5"
     },
     "autoload": {
         "psr-0": { "OAuth2\\ServerBundle": "" }

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     },
     "require-dev": {
         "symfony/symfony": "^2.8|^3",
-        "doctrine/orm": "~2.4,>=2.4.5"
+        "doctrine/orm": "~2.4,>=2.4.5",
+        "phpunit/phpunit": "~6.2"
     },
     "autoload": {
         "psr-0": { "OAuth2\\ServerBundle": "" }


### PR DESCRIPTION
Hi,

here is a little something that can allow developer to hook something on the `oauth.token.response.error` event if needed.

Tell me if you need more.